### PR TITLE
Multiple workspace support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "show-github-info",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "show-github-info",
-			"version": "0.0.1",
+			"version": "0.0.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^22.3.0",
@@ -17,7 +17,7 @@
 				"typescript": "^5.5.2"
 			},
 			"engines": {
-				"vscode": "^1.73.0"
+				"vscode": "^1.92.0"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "show-github-info",
-	"displayName": "Show Github Info",
-	"description": "Show Github Account and Repo Name",
+	"displayName": "Show Git Remote Info",
+	"description": "Show git remote info (as user/repo) in status bar",
 	"version": "0.0.2",
 	"publisher": "oktayaydoan",
 	"private": true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,15 +2,15 @@ import * as vscode from "vscode";
 import * as fs from "fs";
 import * as path from "path";
 
-let myStatusBarItem: vscode.StatusBarItem;
-const defaultRepoInfo = "user/repo";
+let originStatusItem: vscode.StatusBarItem;
+const defaultOriginInfo = "user/repo";
 
 export function activate(context: vscode.ExtensionContext) {
-    myStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 999999999);
+    originStatusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 999999999);
 
-    const repoInfo = getWorkspaceOriginInfo() ?? defaultRepoInfo;
-    myStatusBarItem.text = `$(repo) ${repoInfo}`;
-    myStatusBarItem.show();
+    const originInfo = getWorkspaceOriginInfo() ?? defaultOriginInfo;
+    originStatusItem.text = `$(repo) ${originInfo}`;
+    originStatusItem.show();
 }
 
 function getWorkspaceOriginInfo(): string | null {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,15 +3,14 @@ import * as fs from "fs";
 import * as path from "path";
 
 let myStatusBarItem: vscode.StatusBarItem;
+const defaultRepoInfo = "user/repo";
 
 export function activate(context: vscode.ExtensionContext) {
     myStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 999999999);
 
-    const repoInfo = getRepoAndAccountName();
-    if (repoInfo) {
-        myStatusBarItem.text = `$(repo) ${repoInfo}`;
-        myStatusBarItem.show();
-    }
+    const repoInfo = getRepoAndAccountName() ?? defaultRepoInfo;
+    myStatusBarItem.text = `$(repo) ${repoInfo}`;
+    myStatusBarItem.show();
 }
 
 function getRepoAndAccountName(): string | null {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,12 +10,12 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(originStatusItem);
 
     updateOriginStatusItem();
+    originStatusItem.show();
 }
 
 function updateOriginStatusItem() {
     const originInfo = getWorkspaceOriginInfo() ?? defaultOriginInfo;
     originStatusItem.text = `$(repo) ${originInfo}`;
-    originStatusItem.show();
 }
 
 function getWorkspaceOriginInfo(): string | null {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,12 @@ const defaultOriginInfo = "user/repo";
 
 export function activate(context: vscode.ExtensionContext) {
     originStatusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 999999999);
+    context.subscriptions.push(originStatusItem);
 
+    updateOriginStatusItem();
+}
+
+function updateOriginStatusItem() {
     const originInfo = getWorkspaceOriginInfo() ?? defaultOriginInfo;
     originStatusItem.text = `$(repo) ${originInfo}`;
     originStatusItem.show();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,12 +8,12 @@ const defaultRepoInfo = "user/repo";
 export function activate(context: vscode.ExtensionContext) {
     myStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 999999999);
 
-    const repoInfo = getRepoAndAccountName() ?? defaultRepoInfo;
+    const repoInfo = getWorkspaceOriginInfo() ?? defaultRepoInfo;
     myStatusBarItem.text = `$(repo) ${repoInfo}`;
     myStatusBarItem.show();
 }
 
-function getRepoAndAccountName(): string | null {
+function getWorkspaceOriginInfo(): string | null {
     try {
         const workspaceFolders = vscode.workspace.workspaceFolders;
         if (!workspaceFolders) {
@@ -22,7 +22,7 @@ function getRepoAndAccountName(): string | null {
         const workspacePath = workspaceFolders[0].uri.fsPath;
         return getOriginInfo(workspacePath);
     } catch (error) {
-        console.error("Error getting Git repo and account name:", error);
+        console.error("Error getting git origin info:", error);
     }
     return null;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,47 +5,44 @@ import * as path from "path";
 let myStatusBarItem: vscode.StatusBarItem;
 
 export function activate(context: vscode.ExtensionContext) {
-	myStatusBarItem = vscode.window.createStatusBarItem(
-		vscode.StatusBarAlignment.Left,
-		999999999
-	);
+    myStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 999999999);
 
-	const repoInfo = getRepoAndAccountName();
-	if (repoInfo) {
-		myStatusBarItem.text = `$(repo) ${repoInfo}`;
-		myStatusBarItem.show();
-	}
+    const repoInfo = getRepoAndAccountName();
+    if (repoInfo) {
+        myStatusBarItem.text = `$(repo) ${repoInfo}`;
+        myStatusBarItem.show();
+    }
 }
 
 function getRepoAndAccountName(): string | null {
-	try {
-		const workspaceFolders = vscode.workspace.workspaceFolders;
-		if (!workspaceFolders) {
-			return null;
-		}
+    try {
+        const workspaceFolders = vscode.workspace.workspaceFolders;
+        if (!workspaceFolders) {
+            return null;
+        }
 
-		const workspacePath = workspaceFolders[0].uri.fsPath;
-		const gitConfigPath = path.join(workspacePath, ".git", "config");
+        const workspacePath = workspaceFolders[0].uri.fsPath;
+        const gitConfigPath = path.join(workspacePath, ".git", "config");
 
-		if (!fs.existsSync(gitConfigPath)) {
-			return null;
-		}
+        if (!fs.existsSync(gitConfigPath)) {
+            return null;
+        }
 
-		const configContent = fs.readFileSync(gitConfigPath, "utf-8");
+        const configContent = fs.readFileSync(gitConfigPath, "utf-8");
 
-		let match = configContent.match(/url = https:\/\/github\.com\/(.+)\.git/);
-		if (match) {
-			return match[1];
-		}
+        let match = configContent.match(/url = https:\/\/github\.com\/(.+)\.git/);
+        if (match) {
+            return match[1];
+        }
 
-		match = configContent.match(/url = git@github\.com:(.+)\.git/);
-		if (match) {
-			return match[1];
-		}
+        match = configContent.match(/url = git@github\.com:(.+)\.git/);
+        if (match) {
+            return match[1];
+        }
 
-		return null;
-	} catch (error) {
-		console.error("Error getting Git repo and account name:", error);
-		return null;
-	}
+        return null;
+    } catch (error) {
+        console.error("Error getting Git repo and account name:", error);
+        return null;
+    }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,10 +39,8 @@ function getRepoAndAccountName(): string | null {
         if (match) {
             return match[1];
         }
-
-        return null;
     } catch (error) {
         console.error("Error getting Git repo and account name:", error);
-        return null;
     }
+    return null;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,27 +19,32 @@ function getRepoAndAccountName(): string | null {
         if (!workspaceFolders) {
             return null;
         }
-
         const workspacePath = workspaceFolders[0].uri.fsPath;
-        const gitConfigPath = path.join(workspacePath, ".git", "config");
-
-        if (!fs.existsSync(gitConfigPath)) {
-            return null;
-        }
-
-        const configContent = fs.readFileSync(gitConfigPath, "utf-8");
-
-        let match = configContent.match(/url = https:\/\/github\.com\/(.+)\.git/);
-        if (match) {
-            return match[1];
-        }
-
-        match = configContent.match(/url = git@github\.com:(.+)\.git/);
-        if (match) {
-            return match[1];
-        }
+        return getOriginInfo(workspacePath);
     } catch (error) {
         console.error("Error getting Git repo and account name:", error);
     }
+    return null;
+}
+
+function getOriginInfo(workspacePath: string): string | null {
+    const gitConfigPath = path.join(workspacePath, ".git", "config");
+
+    if (!fs.existsSync(gitConfigPath)) {
+        return null;
+    }
+
+    const configContent = fs.readFileSync(gitConfigPath, "utf-8");
+
+    let match = configContent.match(/url = https:\/\/github\.com\/(.+)\.git/);
+    if (match) {
+        return match[1];
+    }
+
+    match = configContent.match(/url = git@github\.com:(.+)\.git/);
+    if (match) {
+        return match[1];
+    }
+
     return null;
 }


### PR DESCRIPTION
VSCode'da birden fazla repo/klasör açıldığında remote info'nun da güncellenmesi gerekir. Mevcut durumda ilk klasörün bilgisi gösteriliyor. Bu güncelleme ile aktif olan workspace bilgisi gösteriliyor.